### PR TITLE
Add a little more logging to clarify what depstar is doing for each file clash

### DIFF
--- a/src/hf/depstar/uberjar.clj
+++ b/src/hf/depstar/uberjar.clj
@@ -34,8 +34,9 @@
     :noop))
 
 (defmulti clash (fn [filename in target]
-                  (prn {:warning "clashing jar item" :path filename})
-                  (clash-strategy filename)))
+                  (let [stategy (clash-strategy filename)]
+                    (prn {:warning "clashing jar item" :path filename :strategy stategy})
+                    stategy)))
 
 (defmethod clash
   :merge-edn


### PR DESCRIPTION
For example, it was not obvious to me that `data_readers.clj` were being merged, and I only found out after reading the source. I believe the additional logging make that a bit more obvious.