### PR TITLE
Skip pom files ending up on the classpath.

### DIFF
--- a/src/hf/depstar/uberjar.clj
+++ b/src/hf/depstar/uberjar.clj
@@ -111,6 +111,10 @@
              (re-find #"\.jar$" (.toString p)))
         :jar
 
+        (and (Files/isRegularFile p symlink-opts)
+             (re-find #"\.pom$" (.toString p)))
+        :skip
+
         :else :unknown)
       :not-found)))
 
@@ -160,6 +164,11 @@
   :not-found
   [src _dest _options]
   (prn {:warning "could not find classpath entry" :path src}))
+
+(defmethod copy-source*
+  :skip
+  [src _dest _options]
+  (prn {:warning "skipping classpath entry" :path src}))
 
 (defn copy-source
   [src dest options]


### PR DESCRIPTION
Sometimes libraries are badly packaged and you end up with pom files on the
classpath. Before this patch in such cases depstar would bail out. Instead I'm
making an explicit check for pom files and just skip them as the case is
"harmless". If some similat situation comes up for other garbage on class paths
it can be added to this case.

My specific case is when netlib/all 1.1.2 ends up with a pom file on the class
path fwiw (pulled in via the fastmath clojure lib).