### PR TITLE
add support to regex string in compile-ns option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ java -jar MyProject.jar
 
 You can specify namespaces to be AOT-compiled using the `:compile-ns` exec argument. Namespaces specified by `:compile-ns` will be compiled even for thin JAR files, allowing you to build libraries that include `:gen-class`-generated `.class` files. `depstar` creates a temporary folder for the class files and adds it to the classpath roots automatically so that all the classes produced by compilation are added to the JAR. `:compile-ns` accepts a vector of namespace symbols (not regular expressions). It will also accept the keyword `:all` instead of a vector and it will attempt to find all the Clojure namespaces in source files in directories on the classpath (which normally corresponds to your own project's source files, but will also include `:local/root` dependencies and `:git/url` dependencies, since those show up as directories on the classpath).
 
+You can also specify regex strings inside `:compile-ns` vector. Regex strings and symbols for namespaces can coexist in the same vector.
+
 ```bash
 clojure -X:depstar jar :jar MyProject.jar :compile-ns '[project.core]'
 ```

--- a/test/hf/depstar_test.clj
+++ b/test/hf/depstar_test.clj
@@ -76,6 +76,25 @@
         (is (= 4 (count (filter #(str/ends-with? % ".clj") contents))))
         (is (< 50 (count (filter #(str/ends-with? % ".class") contents)) 100))))))
 
+(deftest compile-ns-using-regex-test
+  (let [jar (File/createTempFile "test" ".jar")]
+    (println "[COMPILATION/REGEX]")
+    (testing "Reproducing the same result of :compile-ns with symbol using regex"
+      (is (= {:success true}
+             (sut/build-jar {:jar-type :thin :no-pom true :jar (str jar)
+                             :compile-ns ["hf/depstar.*.clj"]})))
+      (let [contents (:entries (read-jar jar))]
+        (is (< 50 (count (filter #(and (str/starts-with? % "hf/depstar")
+                                       (str/ends-with? % ".class")) contents))
+               100))))
+    (testing "Regex must be a full file match."
+      (is (= {:success true}
+             (sut/build-jar {:jar-type :thin :no-pom true :jar (str jar)
+                             :compile-ns ["hf/deps"]})))
+      (let [contents (:entries (read-jar jar))]
+        (is (zero? (count (filter #(and (str/starts-with? % "hf/depstar")
+                                        (str/ends-with? % ".class")) contents))))))))
+
 (deftest issue-5
   (println "[#5]")
   (let [jar (File/createTempFile "test" ".jar")]

--- a/test/hf/depstar_test.clj
+++ b/test/hf/depstar_test.clj
@@ -93,7 +93,18 @@
                              :compile-ns ["hf.deps"]})))
       (let [contents (:entries (read-jar jar))]
         (is (zero? (count (filter #(and (str/starts-with? % "hf/depstar")
-                                        (str/ends-with? % ".class")) contents))))))))
+                                        (str/ends-with? % ".class")) contents))))))
+    (testing "And symbol with regexp mixed should work too."
+      (is (= {:success true}
+             (sut/build-jar {:jar-type :thin :no-pom true :jar (str jar)
+                             :compile-ns ['hf.depstar "hf.depstar.uber.*"]})))
+      (let [contents (:entries (read-jar jar))]
+        (is (< 50 (count (filter #(and (str/starts-with? % "hf/depstar")
+                                       (str/ends-with? % ".class")) contents))
+               100))
+        (is (< 50 (count (filter #(and (str/starts-with? % "hf/depstar/uberjar")
+                                       (str/ends-with? % ".class")) contents))
+               100))))))
 
 (deftest issue-5
   (println "[#5]")

--- a/test/hf/depstar_test.clj
+++ b/test/hf/depstar_test.clj
@@ -82,7 +82,7 @@
     (testing "Reproducing the same result of :compile-ns with symbol using regex"
       (is (= {:success true}
              (sut/build-jar {:jar-type :thin :no-pom true :jar (str jar)
-                             :compile-ns ["hf/depstar.*.clj"]})))
+                             :compile-ns ["hf.depstar.*"]})))
       (let [contents (:entries (read-jar jar))]
         (is (< 50 (count (filter #(and (str/starts-with? % "hf/depstar")
                                        (str/ends-with? % ".class")) contents))
@@ -90,7 +90,7 @@
     (testing "Regex must be a full file match."
       (is (= {:success true}
              (sut/build-jar {:jar-type :thin :no-pom true :jar (str jar)
-                             :compile-ns ["hf/deps"]})))
+                             :compile-ns ["hf.deps"]})))
       (let [contents (:entries (read-jar jar))]
         (is (zero? (count (filter #(and (str/starts-with? % "hf/depstar")
                                         (str/ends-with? % ".class")) contents))))))))


### PR DESCRIPTION
Hello @seancorfield ,

Recently I needed to add `:compile-ns` to a project in order to compile {clojure,java}-based migration files to Flyway. It works fine, however I would need to explicitly add the name of the namespace for each migration I add to the project and this can get very unhandy with time.

I would like to propose this feature which is very similar to `:all` behavior but I am filtering based on regexp. We can have both strings and symbols coexisting in the same vector e.g. `[app.core "db.migration.*"]`.


If this feature is desired in the repo I would like your comments on how to polish it to include in the project.
Best,