### PR TITLE
Split into tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changes
 
-* 2.0.next in progress
+* 2.0.next in progress 2.1.next? Split into tasks? (will be VGN only)
   * Address #83 by explaining possible `Skipping paths` warning when `:sync-pom true`.
+  * Address #82 by reorganizing internals into three "tasks" that can each be run via the `-X` CLI option. _[This is a work in progress: currently, only the implementation has been broken into tasks -- there is no API namespace for running these tasks directly!]_
   * Address #80 by adding `:delete-on-exit true` exec arg so users can opt-in to early deletion of temporary files and directories, instead of relying on the O/S to clean them "eventually".
   * Address #74 by noting CI environment caching "gotchas".
   * Update `test-runner`.

--- a/src/hf/depstar/aot.clj
+++ b/src/hf/depstar/aot.clj
@@ -1,0 +1,168 @@
+;; copyright (c) 2019-2021 sean corfield
+
+(ns ^:no-doc hf.depstar.aot
+  "AOT compilation logic."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.logging :as logger]
+            [clojure.tools.namespace.find :as tnsf]
+            [hf.depstar.files :as files]
+            [hf.depstar.task :as task])
+  (:import (java.nio.file Files)
+           (java.nio.file.attribute FileAttribute)))
+
+(set! *warn-on-reflection* true)
+
+(defn- compile-arguments
+  "Given a namespace to compile (a symbol), a vector of JVM
+  options to apply, the classpath, a symbol for the compile
+  function, and the temporary directory to write the classes
+  to, return the process arguments that would compile it
+    (java -cp ...).
+  If compile-fn is omitted (nil), clojure.core/compile is
+  used. Otherwise, a require of the namespace is added and
+  a call of resolve is added."
+  [ns-sym jvm-opts cp compile-fn tmp-c-dir]
+  (let [java     (or (System/getenv "JAVA_CMD") "java")
+        windows? (-> (System/getProperty "os.name")
+                     (str/lower-case)
+                     (str/includes? "windows"))
+        comp-req (when-let [comp-ns (and compile-fn (namespace compile-fn))]
+                   (str "(require,'" comp-ns "),"))
+        comp-fn  (if compile-fn
+                   (str "(resolve,'" compile-fn ")")
+                   "compile")
+        args     (-> [java]
+                     (into jvm-opts)
+                     (into ["-cp"
+                            (str/join (System/getProperty "path.separator") cp)
+                            "clojure.main"
+                            "-e"
+                            (str "(binding,[*compile-path*,"
+                                 (pr-str (str tmp-c-dir))
+                                 "]," comp-req "(" comp-fn ",'"
+                                 (name ns-sym)
+                                 "))")]))]
+    (if windows?
+      (mapv #(str/replace % "\"" "\\\"") args)
+      args)))
+
+(defn compile-it
+  "Given a namespace to compile (a symbol), a vector of JVM
+  options to apply, the classpath, a symbol for the compile
+  function, and the temporary directory to write the classes
+  to, compile the namespace and return a Boolean indicating
+  any failures (the failures will be printed to standard
+  error)."
+  [ns-sym jvm-opts cp compile-fn tmp-c-dir]
+  (logger/info "Compiling" ns-sym "...")
+  (let [p (.start
+           (ProcessBuilder.
+            ^"[Ljava.lang.String;"
+            (into-array
+             String
+             (compile-arguments ns-sym jvm-opts cp compile-fn tmp-c-dir))))]
+    (.waitFor p)
+    (let [stderr (slurp (.getErrorStream p))]
+      (when (seq stderr) (println stderr))
+      (if (zero? (.exitValue p))
+        false ; no AOT failure
+        (do
+          (logger/error (str "Compilation of " ns-sym " failed!"))
+          true)))))
+
+(defn task*
+  "Handling of AOT compilation as a -X task.
+
+  Inputs:
+  * aot
+  * classpath
+  * compile-aliases
+  * compile-fn
+  * compile-ns
+  * delete-on-exit
+  * jar-type
+  * main-class
+  * paths-only
+
+  Outputs:
+  * classpath-roots
+  "
+  [options]
+  (let [{:keys [aot classpath compile-aliases compile-fn compile-ns
+                delete-on-exit jar-type jvm-opts main-class paths-only]
+         :or {jar-type :uber}
+         :as options}
+        (task/preprocess-options options)
+        _
+        (when (and aot (= :thin jar-type))
+          (logger/warn ":aot is not recommended for a 'thin' JAR!"))
+        _
+        (when (and jvm-opts (not (sequential? jvm-opts)))
+          (logger/warn ":jvm-opts should be a vector -- ignoring" jvm-opts))
+        jvm-opts   (if (sequential? jvm-opts) (vec jvm-opts) [])
+
+        main-class (some-> main-class str) ; ensure we have a string
+        options    (assoc options ; ensure defaulted/processed options present
+                          :jar-type   jar-type
+                          :main-class main-class)
+
+        basis      (task/calc-project-basis options)
+        c-basis    (if-let [c-aliases (not-empty compile-aliases)]
+                     (task/calc-project-basis (assoc options :aliases c-aliases))
+                     basis)
+
+        cp          (or (some-> classpath (files/parse-classpath))
+                        (if (and paths-only (= :thin jar-type))
+                          (vec (into (set (:paths basis))
+                                     (-> basis :classpath-args :extra-paths)))
+                          (:classpath-roots basis)))
+        c-cp        (or (some-> classpath (files/parse-classpath))
+                        (if (and paths-only (= :thin jar-type))
+                          (vec (into (set (:paths c-basis))
+                                     (-> c-basis :classpath-args :extra-paths)))
+                          (:classpath-roots c-basis)))
+
+        ;; expand :all and regex string using tools.namespace:
+        dir-file-ns (comp
+                     (filter #(= :directory (files/classify %)))
+                     (map io/file)
+                     (mapcat tnsf/find-namespaces-in-dir))
+        compile-ns  (cond (= :all compile-ns)
+                          (into [] dir-file-ns c-cp)
+                          (sequential? compile-ns)
+                          (let [patterns (into []
+                                               (comp (filter string?)
+                                                     (map re-pattern))
+                                               compile-ns)]
+                            (cond-> (filterv symbol? compile-ns)
+                              (seq patterns)
+                              (into (comp
+                                     dir-file-ns
+                                     (filter #(files/included? (str %) patterns)))
+                                    c-cp)))
+                          :else
+                          (when compile-ns
+                            (logger/warn ":compile-ns should be a vector (or :all) -- ignoring")))
+
+        ;; force AOT if compile-ns explicitly requested:
+        do-aot      (or aot (seq compile-ns))
+        ;; compile main-class at least (if also do-aot):
+        compile-ns  (if (and do-aot main-class)
+                      (into (or compile-ns []) [main-class])
+                      compile-ns)
+        _           (when (and aot (empty? compile-ns))
+                      (logger/warn ":aot true but no namespaces to compile -- ignoring"))
+        tmp-c-dir   (when do-aot
+                      (Files/createTempDirectory "depstarc" (make-array FileAttribute 0)))
+        _           (when (and tmp-c-dir delete-on-exit)
+                      (files/delete-path-on-exit tmp-c-dir))
+
+        cp          (into (cond-> [] do-aot (conj (str tmp-c-dir))) cp)
+        c-cp        (into (cond-> [] do-aot (conj (str tmp-c-dir))) c-cp)]
+
+    (when do-aot
+      (when (some #(compile-it % jvm-opts c-cp compile-fn tmp-c-dir)
+                  compile-ns)
+        (throw (ex-info "AOT compilation failed" {}))))
+    (assoc options :classpath-roots cp)))

--- a/src/hf/depstar/aot.clj
+++ b/src/hf/depstar/aot.clj
@@ -47,7 +47,7 @@
       (mapv #(str/replace % "\"" "\\\"") args)
       args)))
 
-(defn compile-it
+(defn- compile-it
   "Given a namespace to compile (a symbol), a vector of JVM
   options to apply, the classpath, a symbol for the compile
   function, and the temporary directory to write the classes

--- a/src/hf/depstar/files.clj
+++ b/src/hf/depstar/files.clj
@@ -1,0 +1,58 @@
+;; copyright (c) 2018-2021 sean corfield, ghadi shayban
+
+(ns ^:no-doc hf.depstar.files
+  "Low-level file handling and classification utilities."
+  (:import (java.nio.file LinkOption FileSystem FileSystems Files Path)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:dynamic *exclude* nil)
+
+(defonce ^:private ^FileSystem FS (FileSystems/getDefault))
+
+(defn path
+  ^Path [s]
+  (.getPath FS s (make-array String 0)))
+
+(defn classify
+  [entry]
+  (let [p (path entry)
+        symlink-opts (make-array LinkOption 0)]
+    (if (Files/exists p symlink-opts)
+      (cond
+        (Files/isDirectory p symlink-opts)
+        :directory
+
+        (and (Files/isRegularFile p symlink-opts)
+             (re-find #"\.jar$" (.toString p)))
+        :jar
+
+        :else :unknown)
+      :not-found)))
+
+(def ^:private exclude-patterns
+  "Filename patterns to exclude. These are checked with re-matches and
+  should therefore be complete filename matches including any path."
+  [#"project.clj"
+   #"(.*/)?\.DS_Store"
+   #"(.*/)?\.keep"
+   #".*\.pom" #"module-info\.class"
+   #"(?i)META-INF/.*\.(?:MF|SF|RSA|DSA)"
+   #"(?i)META-INF/(?:INDEX\.LIST|DEPENDENCIES)(?:\.txt)?"])
+
+(defn excluded?
+  [filename]
+  (or (some #(re-matches % filename) exclude-patterns)
+      (some #(re-matches % filename) *exclude*)))
+
+(defn included?
+  [filename patterns]
+  (some #(re-matches % filename) patterns))
+
+(defn delete-path-on-exit
+  "Given a Path, register it for deletion on exit of this process."
+  [^Path path]
+  (.deleteOnExit (.toFile path)))
+
+(defn parse-classpath [^String cp]
+  (vec (.split cp (System/getProperty "path.separator"))))

--- a/src/hf/depstar/pom.clj
+++ b/src/hf/depstar/pom.clj
@@ -1,0 +1,126 @@
+;; copyright (c) 2019-2021 sean corfield
+
+(ns ^:no-doc hf.depstar.pom
+  "Logic for creating, sync'ing, reading, and copying pom.xml files."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.deps.alpha.gen.pom :as pom]
+            [clojure.tools.logging :as logger]
+            [hf.depstar.task :as task])
+  (:import (java.io File)))
+
+(set! *warn-on-reflection* true)
+
+(defn pom-sync
+  "Give a (pom) file, the project basis, and the options, synchronize
+  the group/artifact/version if requested (using tools.deps.alpha)."
+  [^File pom-file basis {:keys [artifact-id group-id version]}]
+  (let [new-pom (not (.exists pom-file))]
+    ;; #56 require GAV when sync-pom used to create pom.xml:
+    (if (and new-pom (not (and group-id artifact-id version)))
+      (logger/warn "Ignoring :sync-pom because :group-id, :artifact-id, and"
+                   ":version are all required when creating a new 'pom.xml' file!")
+      (do
+        (logger/info "Synchronizing" (.getName pom-file))
+        (pom/sync-pom
+         {:basis basis
+          :params (cond-> {:target-dir (or (.getParent pom-file) ".")
+                           :src-pom    (.getPath pom-file)}
+                    (and new-pom group-id artifact-id)
+                    (assoc :lib (symbol (name group-id) (name artifact-id)))
+                    (and new-pom version)
+                    (assoc :version version))})))))
+
+(defn- first-by-tag
+  [pom-text tag]
+  (-> (re-seq (re-pattern (str "<" (name tag) ">([^<]+)</" (name tag) ">")) pom-text)
+      (first)
+      (second)))
+
+(defn sync-gav
+  "Given a pom file and options, return the group/artifact IDs and
+  the version. These are taken from the options, if present, otherwise
+  they are read in from the pom file.
+
+  Returns a hash map containing the group/artifact IDs, and the version.
+
+  If the values provided in the options differ from those in the pom file,
+  the pom file will be updated to reflect those in the options hash map.
+
+  Throw an exception if we cannot read them from the pom file."
+  [pom-file {:keys [artifact-id group-id version]}]
+  (let [pom-text     (slurp pom-file)
+        artifact-id' (first-by-tag pom-text :artifactId)
+        group-id'    (first-by-tag pom-text :groupId)
+        version'     (first-by-tag pom-text :version)
+        result       {:artifact-id (or artifact-id artifact-id')
+                      :group-id    (or group-id    group-id')
+                      :version     (or version     version')}]
+    (when-not (and (:group-id result) (:artifact-id result) (:version result))
+      (throw (ex-info "Unable to establish group/artifact and version!" result)))
+    ;; do we need to override any of the pom.xml values?
+    (when (or (and artifact-id artifact-id' (not= artifact-id artifact-id'))
+              (and group-id    group-id'    (not= group-id    group-id'))
+              (and version     version'     (not= version     version')))
+      (logger/info "Updating pom.xml file to"
+                   (str "{"
+                        (:group-id result) "/"
+                        (:artifact-id result) " "
+                        "{:mvn/version \"" (:version result) "\"}"
+                        "}"))
+      (spit pom-file
+            (cond-> pom-text
+              (and artifact-id artifact-id' (not= artifact-id artifact-id'))
+              (str/replace-first (str "<artifactId>" artifact-id' "</artifactId>")
+                                 (str "<artifactId>" artifact-id  "</artifactId>"))
+
+              (and group-id    group-id'    (not= group-id group-id'))
+              (str/replace-first (str "<groupId>" group-id' "</groupId>")
+                                 (str "<groupId>" group-id  "</groupId>"))
+
+              (and version     version'     (not= version version'))
+              (->
+               (str/replace-first (str "<version>" version' "</version>")
+                                  (str "<version>" version  "</version>"))
+                ;; also replace <tag> if it matched <version> with any prefix:
+               (str/replace-first (re-pattern (str "<tag>([^<]*)"
+                                                   (java.util.regex.Pattern/quote version')
+                                                   "</tag>"))
+                                  (str "<tag>$1" version "</tag>"))))))
+    result))
+
+(defn task*
+  "Handling of pom.xml as a -X task.
+
+  Inputs (all optional):
+  * artifact-id (string)  -- <artifactId> to write to pom.xml
+  * group-id    (string)  -- <groupId> to write to pom.xml
+  * no-pom      (boolean) -- do not read/update group/artifact/version
+  * pom-file    (string)  -- override default pom.xml path
+  * sync-pom    (boolean) -- sync deps to pom.xml, create if missing
+  * version     (string)  -- <version> to write to pom.xml
+
+  Outputs:
+  * artifact-id (string)  -- if not no-pom, <artifactId> from pom.xml
+  * group-id    (string)  -- if not no-pom, <groupId> from pom.xml
+  * version     (string)  -- if not no-pom, <version> from pom.xml"
+  [options]
+  (let [{:keys [group-id no-pom pom-file sync-pom]
+         :or   {pom-file "pom.xml"}
+         :as   options}
+        (task/preprocess-options options)
+        _
+        (when (and group-id (not (re-find #"\." (str group-id))))
+          (logger/warn ":group-id should probably be a reverse domain name, not just" group-id))
+        ;; ensure defaulted options are present:
+        options    (assoc options :pom-file pom-file)
+
+        basis      (task/calc-project-basis options)
+        ^File
+        pom-file   (io/file pom-file)
+        _
+        (when sync-pom
+          (pom-sync pom-file basis options))]
+    (merge options
+           (when (and (not no-pom) (.exists pom-file))
+             (sync-gav pom-file options)))))

--- a/src/hf/depstar/pom.clj
+++ b/src/hf/depstar/pom.clj
@@ -37,8 +37,9 @@
         (throw (ex-info "When source and target pom differ, source must exist"
                         {:source-pom (.getPath source-pom)
                          :target-pom (.getPath target-pom)}))))
-    ;; #56 require GAV when sync-pom used to create pom.xml:
-    (if (and new-pom (not (and group-id artifact-id version)))
+    ;; #56 require GAV when sync-pom used to create pom.xml, if no source pom:
+    (if (and new-pom (not (.exists source-pom))
+             (not (and group-id artifact-id version)))
       (logger/warn "Ignoring :sync-pom because :group-id, :artifact-id, and"
                    ":version are all required when creating a new 'pom.xml' file!")
       (do

--- a/src/hf/depstar/specs.clj
+++ b/src/hf/depstar/specs.clj
@@ -1,6 +1,9 @@
+;; copyright (c) 2018-2021 sean corfield, ghadi shayban
+
 (ns hf.depstar.specs
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as string]
+            [hf.depstar.files :as f]
             [hf.depstar.uberjar :as u]))
 
 (s/def ::filename string?)
@@ -22,7 +25,7 @@
         :args (s/cat :p ::path
                      :f ifn?))
 
-(s/fdef u/classify
+(s/fdef f/classify
         :args (s/cat :e ::cp-entry)
         :ret ::entry-type)
 

--- a/src/hf/depstar/task.clj
+++ b/src/hf/depstar/task.clj
@@ -1,0 +1,57 @@
+;; copyright (c) 2019-2021 sean corfield
+
+(ns ^:no-doc hf.depstar.task
+  "Utilities to allow parts of depstar to run as -X tasks."
+  (:require [clojure.tools.deps.alpha :as t]
+            [clojure.tools.logging :as logger]))
+
+(set! *warn-on-reflection* true)
+
+(defn- read-edn-files
+  "Given as options map, use tools.deps.alpha to read and merge the
+  applicable `deps.edn` files."
+  [{:keys [repro] :or {repro true}}]
+  (let [{:keys [root-edn user-edn project-edn]} (t/find-edn-maps)]
+    (t/merge-edns (if repro
+                    [root-edn project-edn]
+                    [root-edn user-edn project-edn]))))
+
+(defn calc-project-basis
+  "Given the options map, use tools.deps.alpha to read and merge the
+  applicable `deps.edn` files, combine the specified aliases, calculate
+  the project basis (which will resolve/download dependencies), and
+  return the calculated project basis."
+  [{:keys [aliases] :or {aliases []} :as options}]
+  (let [deps     (read-edn-files options)
+        combined (t/combine-aliases deps aliases)]
+    ;; this could be cleaner, by only selecting the "relevant"
+    ;; keys from combined for each of these three uses (but
+    ;; I'm waiting for the dust to settle on a possible higher-
+    ;; level API appearing in tools.deps.alpha itself):
+    (t/calc-basis (t/tool deps combined)
+                  {:resolve-args   combined
+                   :classpath-args combined})))
+
+(comment
+  (calc-project-basis {})
+  (calc-project-basis {:aliases [:trial]}))
+
+(defn preprocess-options
+  "Given an options hash map, if any of the values are keywords, look them
+  up as alias values from the full basis (including user `deps.edn`).
+
+  :jar-type is the only option that is expected to have a keyword value
+  and it is generally set automatically so we skip the lookup for that."
+  [options]
+  (let [kw-opts #{:compile-ns :jar-type} ; :compile-ns can be :all
+        aliases (:aliases (read-edn-files {:repro false}))]
+    (reduce-kv (fn [opts k v]
+                 (if (and (not (contains? kw-opts k)) (keyword? v))
+                   (if (contains? aliases v)
+                     (assoc opts k (get aliases v))
+                     (do
+                       (logger/warn k "has value" v "which is an unknown alias")
+                       opts))
+                   opts))
+               options
+               options)))

--- a/src/hf/depstar/uberjar.clj
+++ b/src/hf/depstar/uberjar.clj
@@ -413,12 +413,13 @@
   * no-pom
   * paths-only
   * pom-file
+  * target-dir
   * verbose
 
   Outputs (none)."
   [options]
   (let [{:keys [classpath classpath-roots debug-clash delete-on-exit exclude
-                jar jar-type no-pom paths-only pom-file verbose]
+                jar jar-type no-pom paths-only pom-file target-dir verbose]
          :or {jar-type :uber}
          :as options}
         (task/preprocess-options options)
@@ -429,6 +430,11 @@
         (when (not jar)
           (throw (ex-info ":jar option is required" {})))
         jar        (some-> jar str) ; ensure we have a string
+        jar        (if target-dir
+                     (if (.getParent (io/file jar))
+                       jar ; ignore target, jar already contains a path
+                       (str target-dir "/" jar))
+                     jar)
         options    (assoc options ; ensure defaulted/processed options present
                           :jar        jar
                           :jar-type   jar-type)

--- a/src/hf/depstar/uberjar.clj
+++ b/src/hf/depstar/uberjar.clj
@@ -396,6 +396,8 @@
   (println "  :pom-file str      -- optional path to a different 'pom.xml' file")
   (println "  :repro false       -- include user 'deps.edn' when computing the classpath")
   (println "  :sync-pom true     -- synchronize 'pom.xml' dependencies, group, artifact, and version")
+  (println "  :target-dir str    -- specify a target directory for the generated files")
+  (println "                        (pom, classes, jar) which is kept around")
   (println "  :verbose true      -- explain what goes into the JAR file")
   (println "  :version str       -- specify the version (of the group/artifact)"))
 

--- a/src/hf/depstar/uberjar.clj
+++ b/src/hf/depstar/uberjar.clj
@@ -1,15 +1,19 @@
+;; copyright (c) 2018-2021 sean corfield, ghadi shayban
+
 (ns hf.depstar.uberjar
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [clojure.tools.deps.alpha :as t]
-            [clojure.tools.deps.alpha.gen.pom :as pom]
             [clojure.tools.logging :as logger]
-            [clojure.tools.namespace.find :as tnsf])
-  (:import (java.io File InputStream PushbackReader)
+            [hf.depstar.aot :as aot]
+            [hf.depstar.files :as files]
+            [hf.depstar.pom :as pom]
+            [hf.depstar.task :as task])
+  (:import (clojure.lang ExceptionInfo)
+           (java.io File InputStream PushbackReader)
            (java.nio.file CopyOption LinkOption OpenOption
                           StandardCopyOption StandardOpenOption
-                          FileSystem FileSystems Files
+                          FileSystems Files
                           FileVisitOption FileVisitResult FileVisitor
                           Path)
            (java.nio.file.attribute FileAttribute FileTime)
@@ -22,13 +26,7 @@
 (def ^:dynamic ^:private *debug* nil)
 (def ^:dynamic ^:private *debug-clash* nil)
 (def ^:dynamic ^:private *delete-on-exit* nil)
-(def ^:dynamic ^:private *exclude* nil)
 (def ^:dynamic ^:private *verbose* nil)
-
-(defn- delete-path-on-exit
-  "Given a Path, register it for deletion on exit of this process."
-  [^Path path]
-  (.deleteOnExit (.toFile path)))
 
 (defn- env-prop
   "Given a setting name, get its Boolean value from the environment,
@@ -47,8 +45,6 @@
                          :env      (System/getenv env-setting)
                          :property (System/getProperty prop-setting)}))))))
 
-(defonce ^:private ^FileSystem FS (FileSystems/getDefault))
-
 ;; could add (StandardOpenOption/valueOf "SYNC") here as well but that
 ;; could slow things down (and hasn't yet proved to be necessary)
 (def ^:private open-opts (into-array OpenOption [(StandardOpenOption/valueOf "CREATE")]))
@@ -62,10 +58,6 @@
 (defonce ^:private errors (atom 0))
 
 (defonce ^:private multi-release? (atom false))
-
-(defn- path
-  ^Path [s]
-  (.getPath FS s (make-array String 0)))
 
 (def ^:private log4j2-plugins-file
   "Log4j2 has a very problematic binary plugins cache file that needs to
@@ -169,8 +161,8 @@
     (with-open [os (Files/newOutputStream target open-opts)]
       (.writeCache cache os))
     (when *delete-on-exit*
-      (delete-path-on-exit temp2)
-      (delete-path-on-exit temp1))))
+      (files/delete-path-on-exit temp2)
+      (files/delete-path-on-exit temp1))))
 
 (defmethod clash
   :default
@@ -178,29 +170,10 @@
   ;; do nothing, first file wins
   nil)
 
-(def ^:private exclude-patterns
-  "Filename patterns to exclude. These are checked with re-matches and
-  should therefore be complete filename matches including any path."
-  [#"project.clj"
-   #"(.*/)?\.DS_Store"
-   #"(.*/)?\.keep"
-   #".*\.pom" #"module-info\.class"
-   #"(?i)META-INF/.*\.(?:MF|SF|RSA|DSA)"
-   #"(?i)META-INF/(?:INDEX\.LIST|DEPENDENCIES)(?:\.txt)?"])
-
-(defn- excluded?
-  [filename]
-  (or (some #(re-matches % filename) exclude-patterns)
-      (some #(re-matches % filename) *exclude*)))
-
-(defn- included?
-  [filename patterns]
-  (some #(re-matches % filename) patterns))
-
 (defn- copy!
   ;; filename drives strategy
   [filename ^InputStream in ^Path target last-mod]
-  (if-not (excluded? filename)
+  (if-not (files/excluded? filename)
     (if (Files/exists target (make-array LinkOption 0))
       (clash filename in target)
       (do
@@ -224,32 +197,16 @@
     (doseq [entry (enumeration-seq (.entries in-file))]
       (f (.getInputStream in-file entry) entry))))
 
-(defn- classify
-  [entry]
-  (let [p (path entry)
-        symlink-opts (make-array LinkOption 0)]
-    (if (Files/exists p symlink-opts)
-      (cond
-        (Files/isDirectory p symlink-opts)
-        :directory
-
-        (and (Files/isRegularFile p symlink-opts)
-             (re-find #"\.jar$" (.toString p)))
-        :jar
-
-        :else :unknown)
-      :not-found)))
-
 (defmulti ^:private copy-source*
   (fn [src _dest _options]
-    (classify src)))
+    (files/classify src)))
 
 (defmethod copy-source*
   :jar
   [src dest options]
   (when-not (= :thin (:jar-type options))
     (when *verbose* (println src))
-    (consume-jar (path src)
+    (consume-jar (files/path src)
       (fn [inputstream ^ZipEntry entry]
         (let [^String name (.getName entry)
               last-mod (.getLastModifiedTime entry)
@@ -293,7 +250,7 @@
   :directory
   [src dest _options]
   (when *verbose* (println src))
-  (copy-directory (path src) dest))
+  (copy-directory (files/path src) dest))
 
 (defmethod copy-source*
   :not-found
@@ -303,104 +260,13 @@
 (defmethod copy-source*
   :unknown
   [src _dest _options]
-  (if (excluded? src)
+  (if (files/excluded? src)
     (when *debug* (prn {:excluded src}))
     (prn {:warning "ignoring unknown file type" :path src})))
 
 (defn- copy-source
   [src dest options]
   (copy-source* src dest options))
-
-(defn- read-edn-files
-  "Given as options map, use tools.deps.alpha to read and merge the
-  applicable `deps.edn` files."
-  [{:keys [repro] :or {repro true}}]
-  (let [{:keys [root-edn user-edn project-edn]} (t/find-edn-maps)]
-    (t/merge-edns (if repro
-                    [root-edn project-edn]
-                    [root-edn user-edn project-edn]))))
-
-(defn- calc-project-basis
-  "Given the options map, use tools.deps.alpha to read and merge the
-  applicable `deps.edn` files, combine the specified aliases, calculate
-  the project basis (which will resolve/download dependencies), and
-  return the calculated project basis."
-  [{:keys [aliases] :or {aliases []} :as options}]
-  (let [deps     (read-edn-files options)
-        combined (t/combine-aliases deps aliases)]
-    ;; this could be cleaner, by only selecting the "relevant"
-    ;; keys from combined for each of these three uses (but
-    ;; I'm waiting for the dust to settle on a possible higher-
-    ;; level API appearing in tools.deps.alpha itself):
-    (t/calc-basis (t/tool deps combined)
-                  {:resolve-args   combined
-                   :classpath-args combined})))
-
-(comment
-  (calc-project-basis {})
-  (calc-project-basis {:aliases [:trial]})
-  ,)
-
-(defn- parse-classpath [^String cp]
-  (vec (.split cp (System/getProperty "path.separator"))))
-
-(defn- first-by-tag
-  [pom-text tag]
-  (-> (re-seq (re-pattern (str "<" (name tag) ">([^<]+)</" (name tag) ">")) pom-text)
-      (first)
-      (second)))
-
-(defn- sync-gav
-  "Given a pom file and options, return the group/artifact IDs and
-  the version. These are taken from the options, if present, otherwise
-  they are read in from the pom file.
-
-  Returns a hash map containing the group/artifact IDs, and the version.
-
-  If the values provided in the options differ from those in the pom file,
-  the pom file will be updated to reflect those in the options hash map.
-
-  Throw an exception if we cannot read them from the pom file."
-  [pom-file {:keys [artifact-id group-id version]}]
-  (let [pom-text     (slurp pom-file)
-        artifact-id' (first-by-tag pom-text :artifactId)
-        group-id'    (first-by-tag pom-text :groupId)
-        version'     (first-by-tag pom-text :version)
-        result       {:artifact-id (or artifact-id artifact-id')
-                      :group-id    (or group-id    group-id')
-                      :version     (or version     version')}]
-    (when-not (and (:group-id result) (:artifact-id result) (:version result))
-      (throw (ex-info "Unable to establish group/artifact and version!" result)))
-    ;; do we need to override any of the pom.xml values?
-    (when (or (and artifact-id artifact-id' (not= artifact-id artifact-id'))
-              (and group-id    group-id'    (not= group-id    group-id'))
-              (and version     version'     (not= version     version')))
-      (logger/info "Updating pom.xml file to"
-                   (str "{"
-                        (:group-id result) "/"
-                        (:artifact-id result) " "
-                        "{:mvn/version \"" (:version result) "\"}"
-                        "}"))
-      (spit pom-file
-            (cond-> pom-text
-              (and artifact-id artifact-id' (not= artifact-id artifact-id'))
-              (str/replace-first (str "<artifactId>" artifact-id' "</artifactId>")
-                                 (str "<artifactId>" artifact-id  "</artifactId>"))
-
-              (and group-id    group-id'    (not= group-id group-id'))
-              (str/replace-first (str "<groupId>" group-id' "</groupId>")
-                                 (str "<groupId>" group-id  "</groupId>"))
-
-              (and version     version'     (not= version version'))
-              (->
-                (str/replace-first (str "<version>" version' "</version>")
-                                   (str "<version>" version  "</version>"))
-                ;; also replace <tag> if it matched <version> with any prefix:
-                (str/replace-first (re-pattern (str "<tag>([^<]*)"
-                                                    (java.util.regex.Pattern/quote version')
-                                                    "</tag>"))
-                                   (str "<tag>$1" version "</tag>"))))))
-    result))
 
 (defn- manifest-properties
   "Given a hash map of options, if `:manifest` is present and
@@ -472,8 +338,7 @@
   "Given a pom.xml file and options, build pom.properties, and add that
   and the pom.xml file to the JAR."
   [^Path dest ^File pom-file options]
-  (let [{:keys [artifact-id group-id version]}
-        (sync-gav pom-file options)
+  (let [{:keys [artifact-id group-id version]} options
         build-now   (java.util.Date.)
         last-mod    (FileTime/fromMillis (.getTime build-now))
         properties  (str "#Generated by depstar\n"
@@ -502,84 +367,6 @@
       (copy! "pom.xml" is
              (.resolve dest (str maven-dir "pom.xml"))
              last-mod))))
-
-(defn- pom-sync
-  "Give a (pom) file, the project basis, and the options, synchronize
-  the group/artifact/version if requested (using tools.deps.alpha)."
-  [^File pom-file basis {:keys [artifact-id group-id version]}]
-  (let [new-pom (not (.exists pom-file))]
-    ;; #56 require GAV when sync-pom used to create pom.xml:
-    (if (and new-pom (not (and group-id artifact-id version)))
-      (logger/warn "Ignoring :sync-pom because :group-id, :artifact-id, and"
-                   ":version are all required when creating a new 'pom.xml' file!")
-      (do
-        (logger/info "Synchronizing" (.getName pom-file))
-        (pom/sync-pom
-         {:basis basis
-          :params (cond-> {:target-dir (or (.getParent pom-file) ".")
-                           :src-pom    (.getPath pom-file)}
-                    (and new-pom group-id artifact-id)
-                    (assoc :lib (symbol (name group-id) (name artifact-id)))
-                    (and new-pom version)
-                    (assoc :version version))})))))
-
-(defn- compile-arguments
-  "Given a namespace to compile (a symbol), a vector of JVM
-  options to apply, the classpath, a symbol for the compile
-  function, and the temporary directory to write the classes
-  to, return the process arguments that would compile it
-    (java -cp ...).
-  If compile-fn is omitted (nil), clojure.core/compile is
-  used. Otherwise, a require of the namespace is added and
-  a call of resolve is added."
-  [ns-sym jvm-opts cp compile-fn tmp-c-dir]
-  (let [java     (or (System/getenv "JAVA_CMD") "java")
-        windows? (-> (System/getProperty "os.name")
-                     (str/lower-case)
-                     (str/includes? "windows"))
-        comp-req (when-let [comp-ns (and compile-fn (namespace compile-fn))]
-                   (str "(require,'" comp-ns "),"))
-        comp-fn  (if compile-fn
-                   (str "(resolve,'" compile-fn ")")
-                   "compile")
-        args     (-> [java]
-                     (into jvm-opts)
-                     (into ["-cp"
-                            (str/join (System/getProperty "path.separator") cp)
-                            "clojure.main"
-                            "-e"
-                            (str "(binding,[*compile-path*,"
-                                 (pr-str (str tmp-c-dir))
-                                 "]," comp-req "(" comp-fn ",'"
-                                 (name ns-sym)
-                                 "))")]))]
-    (if windows?
-      (mapv #(str/replace % "\"" "\\\"") args)
-      args)))
-
-(defn- compile-it
-  "Given a namespace to compile (a symbol), a vector of JVM
-  options to apply, the classpath, a symbol for the compile
-  function, and the temporary directory to write the classes
-  to, compile the namespace and return a Boolean indicating
-  any failures (the failures will be printed to standard
-  error)."
-  [ns-sym jvm-opts cp compile-fn tmp-c-dir]
-  (logger/info "Compiling" ns-sym "...")
-  (let [p (.start
-           (ProcessBuilder.
-            ^"[Ljava.lang.String;"
-            (into-array
-             String
-             (compile-arguments ns-sym jvm-opts cp compile-fn tmp-c-dir))))]
-    (.waitFor p)
-    (let [stderr (slurp (.getErrorStream p))]
-      (when (seq stderr) (println stderr))
-      (if (zero? (.exitValue p))
-        false ; no AOT failure
-        (do
-          (logger/error (str "Compilation of " ns-sym " failed!"))
-          true)))))
 
 (defn- print-help []
   (println "library usage:")
@@ -612,25 +399,86 @@
   (println "  :verbose true      -- explain what goes into the JAR file")
   (println "  :version str       -- specify the version (of the group/artifact)"))
 
-(defn- preprocess-options
-  "Given an options hash map, if any of the values are keywords, look them
-  up as alias values from the full basis (including user `deps.edn`).
+(defn- task*
+  "Handling of JAR building as a -X task.
 
-  :jar-type is the only option that is expected to have a keyword value
-  and it is generally set automatically so we skip the lookup for that."
+  Inputs (all optional, except where noted):
+  * classpath
+  * classpath-roots
+  * debug-clash
+  * delete-on-exit
+  * exclude
+  * jar (required)
+  * jar-type
+  * no-pom
+  * paths-only
+  * pom-file
+  * verbose
+
+  Outputs (none)."
   [options]
-  (let [kw-opts #{:compile-ns :jar-type} ; :compile-ns can be :all
-        aliases (:aliases (read-edn-files {:repro false}))]
-    (reduce-kv (fn [opts k v]
-                 (if (and (not (contains? kw-opts k)) (keyword? v))
-                   (if (contains? aliases v)
-                     (assoc opts k (get aliases v))
-                     (do
-                       (logger/warn k "has value" v "which is an unknown alias")
-                       opts))
-                   opts))
-               options
-               options)))
+  (let [{:keys [classpath classpath-roots debug-clash delete-on-exit exclude
+                jar jar-type no-pom paths-only pom-file verbose]
+         :or {jar-type :uber}
+         :as options}
+        (task/preprocess-options options)
+        _
+        (when (and (not= :thin jar-type) paths-only)
+          (logger/warn ":paths-only is ignored when building an uberjar"))
+        _
+        (when (not jar)
+          (throw (ex-info ":jar option is required" {})))
+        jar        (some-> jar str) ; ensure we have a string
+        options    (assoc options ; ensure defaulted/processed options present
+                          :jar        jar
+                          :jar-type   jar-type)
+        basis      (task/calc-project-basis options)
+        cp         (or (some-> classpath (files/parse-classpath))
+                       (if (and paths-only (= :thin jar-type))
+                         (vec (into (set (:paths basis))
+                                    (-> basis :classpath-args :extra-paths)))
+                         (:classpath-roots basis)))
+        ^File
+        pom-file   (io/file (or pom-file "pom.xml"))
+
+        classpath-roots (or classpath-roots cp)
+
+        tmp-z-dir (Files/createTempDirectory "depstarz" (make-array FileAttribute 0))
+        _         (when delete-on-exit
+                         ;; the JAR file is created in this directory and then
+                         ;; moved to the target location but we may still need
+                         ;; to clean up the temporary directory itself:
+                    (files/delete-path-on-exit tmp-z-dir))
+        dest-name (str/replace jar #"^.*[/\\]" "")
+        jar-path  (.resolve tmp-z-dir ^String dest-name)
+        jar-file  (java.net.URI. (str "jar:" (.toUri jar-path)))
+        zip-opts  (doto (java.util.HashMap.)
+                    (.put "create" "true")
+                    (.put "encoding" "UTF-8"))]
+
+    ;; copy everything to a temporary ZIP (JAR) file:
+    (with-open [zfs (FileSystems/newFileSystem jar-file zip-opts)]
+      (let [tmp (.getPath zfs "/" (make-array String 0))]
+        (reset! errors 0)
+        (reset! multi-release? false)
+        (logger/info "Building" (name jar-type) "jar:" jar)
+        (binding [*debug* (env-prop "debug")
+                  *debug-clash* debug-clash
+                  *delete-on-exit* delete-on-exit
+                  files/*exclude* (mapv re-pattern exclude)
+                  *verbose* verbose]
+          (run! #(copy-source % tmp options) classpath-roots)
+          (copy-manifest tmp options)
+          (when (and (not no-pom) (.exists pom-file))
+            (copy-pom tmp pom-file options)))))
+    ;; move the temporary file to its final location:
+    (let [dest-path (files/path jar)
+          parent (.getParent dest-path)]
+      (when parent (.. parent toFile mkdirs))
+      (Files/move jar-path dest-path copy-opts))
+    (when (pos? @errors)
+      (throw (ex-info "JAR building failed" {})))
+    options))
 
 (defn build-jar
   "Core functionality for depstar. Can be called from a REPL or as a library.
@@ -655,130 +503,20 @@
    {:success false :reason :no-jar}
 
    :else
-   (let [{:keys [aot classpath compile-aliases compile-fn compile-ns
-                 debug-clash delete-on-exit exclude
-                 group-id jar jar-type jvm-opts main-class no-pom paths-only
-                 pom-file sync-pom verbose]
-          :or {jar-type :uber}
-          :as options}
-         (preprocess-options options)
-         jar        (some-> jar str) ; ensure we have a string
-         _          (when (and (not= :thin jar-type) paths-only)
-                      (logger/warn ":paths-only is ignored when building an uberjar"))
-         _          (when (and jvm-opts (not (sequential? jvm-opts)))
-                      (logger/warn ":jvm-opts should be a vector -- ignoring" jvm-opts))
-         _          (when (and group-id (not (re-find #"\." (str group-id))))
-                      (logger/warn ":group-id should probably be a reverse domain name, not just" group-id))
-         jvm-opts   (if (sequential? jvm-opts) (vec jvm-opts) [])
-         main-class (some-> main-class str) ; ensure we have a string
-         options    (assoc options ; ensure defaulted/processed options present
-                           :jar        jar
-                           :jar-type   jar-type
-                           :main-class main-class)
-         basis      (calc-project-basis options)
-         c-basis    (if-let [c-aliases (not-empty compile-aliases)]
-                      (calc-project-basis (assoc options :aliases c-aliases))
-                      basis)
-         ^File
-         pom-file   (io/file (or pom-file "pom.xml"))
-         _
-         (when sync-pom
-           (pom-sync pom-file basis options))
-         _
-         (when (and aot (= :thin jar-type))
-           (logger/warn ":aot is not recommended for a 'thin' JAR!"))
-
-         cp          (or (some-> classpath (parse-classpath))
-                         (if (and paths-only (= :thin jar-type))
-                           (vec (into (set (:paths basis))
-                                      (-> basis :classpath-args :extra-paths)))
-                           (:classpath-roots basis)))
-         c-cp        (or (some-> classpath (parse-classpath))
-                         (if (and paths-only (= :thin jar-type))
-                           (vec (into (set (:paths c-basis))
-                                      (-> c-basis :classpath-args :extra-paths)))
-                           (:classpath-roots c-basis)))
-
-          ;; expand :all and regex string using tools.namespace:
-         dir-file-ns (comp
-                      (filter #(= :directory (classify %)))
-                      (map io/file)
-                      (mapcat tnsf/find-namespaces-in-dir))
-         compile-ns  (cond (= :all compile-ns)
-                           (into [] dir-file-ns c-cp)
-                           (sequential? compile-ns)
-                           (let [patterns (into []
-                                                (comp (filter string?)
-                                                      (map re-pattern))
-                                                compile-ns)]
-                             (cond-> (filterv symbol? compile-ns)
-                               (seq patterns)
-                               (into (comp
-                                      dir-file-ns
-                                      (filter #(included? (str %) patterns)))
-                                     c-cp)))
-                           :else
-                           (when compile-ns
-                             (logger/warn ":compile-ns should be a vector (or :all) -- ignoring")))
-
-          ;; force AOT if compile-ns explicitly requested:
-         do-aot      (or aot (seq compile-ns))
-          ;; compile main-class at least (if also do-aot):
-         compile-ns  (if (and do-aot main-class)
-                       (into (or compile-ns []) [main-class])
-                       compile-ns)
-         _           (when (and aot (empty? compile-ns))
-                       (logger/warn ":aot true but no namespaces to compile -- ignoring"))
-         tmp-c-dir   (when do-aot
-                       (Files/createTempDirectory "depstarc" (make-array FileAttribute 0)))
-         _           (when (and tmp-c-dir delete-on-exit)
-                       (delete-path-on-exit tmp-c-dir))
-         cp          (into (cond-> [] do-aot (conj (str tmp-c-dir))) cp)
-         c-cp        (into (cond-> [] do-aot (conj (str tmp-c-dir))) c-cp)
-         aot-failure (when do-aot
-                       (some #(compile-it % jvm-opts c-cp compile-fn tmp-c-dir)
-                             compile-ns))]
+   (let [options (pom/task* options)
+         {:keys [aot-failure] :as options}
+         (try
+           (aot/task* options)
+           (catch ExceptionInfo _
+             (assoc options :aot-failure true)))]
 
      (if aot-failure
-
        {:success false :reason :aot-failed}
-
-       (let [tmp-z-dir (Files/createTempDirectory "depstarz" (make-array FileAttribute 0))
-             _         (when delete-on-exit
-                         ;; the JAR file is created in this directory and then
-                         ;; moved to the target location but we may still need
-                         ;; to clean up the temporary directory itself:
-                         (delete-path-on-exit tmp-z-dir))
-             dest-name (str/replace jar #"^.*[/\\]" "")
-             jar-path  (.resolve tmp-z-dir ^String dest-name)
-             jar-file  (java.net.URI. (str "jar:" (.toUri jar-path)))
-             zip-opts  (doto (java.util.HashMap.)
-                         (.put "create" "true")
-                         (.put "encoding" "UTF-8"))]
-          ;; copy everything to a temporary ZIP (JAR) file:
-         (with-open [zfs (FileSystems/newFileSystem jar-file zip-opts)]
-           (let [tmp (.getPath zfs "/" (make-array String 0))]
-             (reset! errors 0)
-             (reset! multi-release? false)
-             (logger/info "Building" (name jar-type) "jar:" jar)
-             (binding [*debug* (env-prop "debug")
-                       *debug-clash* debug-clash
-                       *delete-on-exit* delete-on-exit
-                       *exclude* (mapv re-pattern exclude)
-                       *verbose* verbose]
-               (run! #(copy-source % tmp options) cp)
-               (copy-manifest tmp options)
-               (when (and (not no-pom) (.exists pom-file))
-                 (copy-pom tmp pom-file options)))))
-          ;; move the temporary file to its final location:
-         (let [dest-path (path jar)
-               parent (.getParent dest-path)]
-           (when parent (.. parent toFile mkdirs))
-           (Files/move jar-path dest-path copy-opts))
-          ;; was it successful?
-         (if (pos? @errors)
-           {:success false :reason :copy-failure}
-           {:success true}))))))
+       (try
+         (task* options)
+         {:success true}
+         (catch ExceptionInfo _
+           {:success false :reason :copy-failure}))))))
 
 (defn ^:no-doc run*
   "Deprecated entry point for REPL or library usage.


### PR DESCRIPTION
Breaks the uberjar machinery up into three internal tasks: create/sync pom, AOT compilation, JAR building.

Also adds a new `:target-dir` argument (to behave more like other tooling out there).